### PR TITLE
fix(lexicon): register STATEMENT_PRODUCER kafka client and remove dup…

### DIFF
--- a/apps/lexicon/src/lexicon/lexicon.module.ts
+++ b/apps/lexicon/src/lexicon/lexicon.module.ts
@@ -10,7 +10,6 @@ import {
 import { InteractionService } from 'src/interaction/interaction.service';
 import { Statement, StatementToken } from 'src/statement/statement.entity';
 import { StatementModule } from 'src/statement/statement.module';
-import { StatementService } from 'src/statement/statement.service';
 import { LexiconIngestService } from './ingest/lexicon.ingest.service';
 import { LexiconController } from './lexicon.controller';
 import { RedisProfileService } from './profile.service';
@@ -39,7 +38,6 @@ import { WordScoringService } from './scoring.service';
     RedisProfileService,
     InteractionService,
     CefrAssessmentService,
-    StatementService,
     WordScoringService,
   ],
   exports: [],

--- a/apps/lexicon/src/statement/statement.module.ts
+++ b/apps/lexicon/src/statement/statement.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { ClientsModule, Transport } from '@nestjs/microservices';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { BankModule } from 'src/bank/bank.module';
 import { InteractionModule } from 'src/interaction/interaction.module';
@@ -9,6 +10,22 @@ import { StatementService } from './statement.service';
 @Module({
   imports: [
     TypeOrmModule.forFeature([Statement, StatementToken]),
+    ClientsModule.register([
+      {
+        name: 'STATEMENT_PRODUCER',
+        transport: Transport.KAFKA,
+        options: {
+          client: {
+            brokers: [process.env.KAFKA_BROKERS || 'kafka:9092'],
+          },
+          consumer: {
+            groupId:
+              process.env.KAFKA_STATEMENT_PRODUCER_GROUP_ID ||
+              'lexicon-statement-producer-group',
+          },
+        },
+      },
+    ]),
     BankModule,
     InteractionModule,
   ],


### PR DESCRIPTION
…licate StatementService provider

## Summary

-

## Linked Issue

Closes #13 

## Deployment Metadata

- Deploy impact label: `deploy:frontend` | `deploy:backend` | `deploy:both` | `deploy:none`
- Environment label: `env:staging` | `env:prod`

## Validation

- [ ] Tests/build pass locally or in CI
- [ ] Rollout plan included (for risky changes)
- [ ] Rollback plan included (for risky changes)
