### PR TITLE
fix(ci): use Amplify manual deployment API for web deploy

### DIFF
--- a/.github/workflows/web-amplify-deploy.yml
+++ b/.github/workflows/web-amplify-deploy.yml
@@ -20,6 +20,15 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
       - name: Validate required secrets
         env:
           APP_ID: ${{ secrets.AMPLIFY_WEB_APP_ID }}
@@ -40,9 +49,18 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
 
-      - name: Trigger Amplify deploy
+      - name: Build web artifact
+        run: |
+          set -euo pipefail
+          npm ci
+          npm run build --workspace web
+          cd apps/web/build/compute/default
+          npm i --omit=dev
+
+      - name: Upload artifact and start Amplify deployment
         env:
           APP_ID: ${{ secrets.AMPLIFY_WEB_APP_ID }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
           EVENT_NAME: ${{ github.event_name }}
           INPUT_BRANCH: ${{ inputs.branch }}
           REF_NAME: ${{ github.ref_name }}
@@ -53,11 +71,22 @@ jobs:
             BRANCH_NAME="$INPUT_BRANCH"
           fi
 
-          JOB_ID="$(aws amplify start-job \
+          cd apps/web/build
+          zip -r /tmp/web-build.zip .
+
+          read -r JOB_ID ZIP_UPLOAD_URL <<< "$(aws amplify create-deployment \
             --app-id "$APP_ID" \
             --branch-name "$BRANCH_NAME" \
-            --job-type RELEASE \
-            --query 'jobSummary.jobId' \
+            --region "$AWS_REGION" \
+            --query '[jobId,zipUploadUrl]' \
             --output text)"
 
-          echo "Started Amplify job $JOB_ID for branch $BRANCH_NAME"
+          curl -sS -X PUT -T /tmp/web-build.zip "$ZIP_UPLOAD_URL"
+
+          aws amplify start-deployment \
+            --app-id "$APP_ID" \
+            --branch-name "$BRANCH_NAME" \
+            --job-id "$JOB_ID" \
+            --region "$AWS_REGION"
+
+          echo "Started Amplify deployment job $JOB_ID for branch $BRANCH_NAME"


### PR DESCRIPTION
## Summary

-

## Linked Issue

Closes #19 

## Deployment Metadata

- Deploy impact label: `deploy:frontend` | `deploy:backend` | `deploy:both` | `deploy:none`
- Environment label: `env:staging` | `env:prod`

## Validation

- [ ] Tests/build pass locally or in CI
- [ ] Rollout plan included (for risky changes)
- [ ] Rollback plan included (for risky changes)
