### PR TITLE
fix(amplify): align monorepo appRoot for web build

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -1,7 +1,9 @@
 version: 1
 applications:
-  - appRoot: .
+  - appRoot: apps/web
     frontend:
+      # Run commands from repo root so npm workspace scripts resolve correctly.
+      buildPath: /
       phases:
         preBuild:
           commands:


### PR DESCRIPTION
## Summary

-

## Linked Issue

Closes #19 

## Deployment Metadata

- Deploy impact label: `deploy:frontend`
- Environment label: `env:prod`

## Validation

- [ ] Tests/build pass locally or in CI
- [ ] Rollout plan included (for risky changes)
- [ ] Rollback plan included (for risky changes)
