### PR TITLE
docs(architecture): add single-entrypoint migration roadmap

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ This repository keeps operational and engineering documentation versioned with c
 - [Deployment and Operations](./deployment.md)
 - [Project Management (GitHub)](./project-management.md)
 - [System Architecture](./architecture.md)
+- [Single Entrypoint Roadmap](./single-entrypoint-roadmap.md)
 - [Architecture Decision Records](./adr/README.md)
 
 ## Source of Truth

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -138,3 +138,13 @@ When a PR changes service boundaries, dependencies, integration paths, or core r
 
 - Update this page, or
 - Add an ADR in `docs/adr/` and link it in the PR.
+
+## Planned Topology Change
+
+An active migration is in progress to consolidate frontend ingress through `client`:
+
+- `web` will move from direct `business`/`waitlist` calls to `client` endpoints.
+- Public API ingress will be limited to a single `client` entrypoint.
+- Domain services remain internal-only.
+
+Roadmap: [Single Entrypoint Roadmap](./single-entrypoint-roadmap.md)

--- a/docs/single-entrypoint-roadmap.md
+++ b/docs/single-entrypoint-roadmap.md
@@ -1,0 +1,45 @@
+# Single Entrypoint Roadmap (Web -> Client)
+
+This roadmap defines the migration to a single public backend entrypoint for frontend traffic.
+
+## Target State
+
+- Public frontend host (`web`) calls one public API domain only.
+- Public API domain routes to `client` service.
+- Domain services (`business`, `waitlist`, `discounts`, etc.) are internal-only and not directly exposed to frontend.
+- Web runtime no longer requires per-service internal URLs.
+
+## Current vs Target
+
+Current:
+
+- `web` uses direct service proxies for `business` and `waitlist`.
+- `app-web` and `admin-web` already call `client`.
+
+Target:
+
+- `web`, `app-web`, and `admin-web` all call `client`.
+- `client` owns cross-service orchestration and external-facing API surface.
+
+## Phased Execution
+
+1. Add `client` endpoints for waitlist flows.
+2. Add `client` endpoints for web survey/business flows.
+3. Refactor `web` routes to call `client` endpoints only.
+4. Remove direct service URL dependencies from `web` env config.
+5. Restrict public exposure to `client` API entrypoint and frontend hosts.
+6. Validate and document rollback/recovery checkpoints.
+
+## Acceptance Criteria
+
+- `web` has no direct runtime dependency on `WAITLIST_API_URL`/`BUSINESS_API_URL`.
+- All web integration traffic goes through `client`.
+- Public ingress policy exposes only intended entrypoints.
+- Staging and production smoke tests pass for waitlist/survey flows.
+
+## Rollback Strategy
+
+- Keep old web proxy handlers behind feature flag or branch fallback during migration.
+- Revert web endpoint targets to previous service URLs if `client` proxy routes regress.
+- Roll back `client` endpoint changes by image tag if required.
+


### PR DESCRIPTION
## Summary

-

## Linked Issue

Closes #27 

## Deployment Metadata

- Deploy impact label: `deploy:frontend` | `deploy:backend` | `deploy:both` | `deploy:none`
- Environment label: `env:staging` | `env:prod`

## Documentation Impact

- [ ] Updated deployment docs (`docs/deployment.md`) if deploy/config behavior changed
- [ ] Updated architecture docs (`docs/architecture.md` or `docs/adr/*`) if service interaction/topology changed
- [ ] No architecture documentation impact
- [ ] No documentation impact

## Validation

- [ ] Tests/build pass locally or in CI
- [ ] Rollout plan included (for risky changes)
- [ ] Rollback plan included (for risky changes)
