### PR TITLE
chore(web,ci,docs): add taster endpoint/page smoke checks and runbook…

### DIFF
--- a/.github/workflows/web-amplify-deploy.yml
+++ b/.github/workflows/web-amplify-deploy.yml
@@ -187,7 +187,9 @@ jobs:
           }
 
           require_status 200 "/"
+          require_status 200 "/taster"
           require_status 200 "/survey/setup"
+          require_status 200 "/api/courses/taster"
           require_status 200 "/api/surveys/templates/public/appetite"
           require_status 400 "/api/surveys/campaigns" "POST" '{"businessName":"Smoke Test Cafe","town":"Galway"}'
           require_status 400 "/api/waitlist" "POST" '{"email":"smoke@example.com","interest":"invalid_interest"}'

--- a/apps/web/src/routes/api/courses/[...path]/+server.ts
+++ b/apps/web/src/routes/api/courses/[...path]/+server.ts
@@ -1,0 +1,11 @@
+import type { RequestHandler } from './$types';
+import { forwardCoursesRequest } from '../_proxy';
+
+function suffix(path: string) {
+  return path ? `/${path}` : '';
+}
+
+export const GET: RequestHandler = (event) =>
+  forwardCoursesRequest(event, suffix(event.params.path || ''), 'GET');
+export const POST: RequestHandler = (event) =>
+  forwardCoursesRequest(event, suffix(event.params.path || ''), 'POST');

--- a/apps/web/src/routes/api/courses/_proxy.ts
+++ b/apps/web/src/routes/api/courses/_proxy.ts
@@ -1,0 +1,75 @@
+import { json, type RequestEvent } from '@sveltejs/kit';
+
+function baseUrls() {
+  const configured = (process.env.CLIENT_API_URL || '').trim();
+  const configuredNest = (process.env.NEST_INTERNAL_URL || '').trim();
+  const candidates = [
+    configured,
+    configuredNest,
+    'http://client:8000',
+    'http://127.0.0.1:8000',
+    'http://localhost:8000',
+  ]
+    .filter(Boolean)
+    .map((url) => url.replace(/\/$/, ''));
+
+  return [...new Set(candidates)];
+}
+
+async function readBody(request: Request, method: string) {
+  if (method === 'GET' || method === 'HEAD') {
+    return undefined;
+  }
+  return request.arrayBuffer();
+}
+
+export async function forwardCoursesRequest(event: RequestEvent, pathSuffix: string, method: string) {
+  const headers = new Headers(event.request.headers);
+
+  const hopByHopHeaders = [
+    'host',
+    'connection',
+    'keep-alive',
+    'proxy-authenticate',
+    'proxy-authorization',
+    'te',
+    'trailer',
+    'transfer-encoding',
+    'upgrade',
+  ];
+  for (const header of hopByHopHeaders) {
+    headers.delete(header);
+  }
+
+  const requestBody = await readBody(event.request, method);
+  let lastError: unknown;
+
+  for (const baseUrl of baseUrls()) {
+    const upstream = `${baseUrl}/courses${pathSuffix}${event.url.search}`;
+    try {
+      const response = await event.fetch(upstream, {
+        method,
+        headers,
+        body: requestBody,
+      });
+
+      const contentType = response.headers.get('content-type') || '';
+      if (contentType.includes('application/json')) {
+        return json(await response.json(), { status: response.status });
+      }
+
+      return new Response(await response.text(), {
+        status: response.status,
+        headers: {
+          'content-type': contentType || 'text/plain',
+        },
+      });
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  const message =
+    lastError instanceof Error ? lastError.message : 'Courses proxy failed';
+  return json({ error: message }, { status: 502 });
+}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -86,7 +86,22 @@ Operational checks:
 docker compose --env-file /opt/misneach/.env -f /opt/misneach/docker-compose.prod.yml ps api-proxy client
 docker compose --env-file /opt/misneach/.env -f /opt/misneach/docker-compose.prod.yml exec api-proxy wget -q -O - http://127.0.0.1/healthz
 docker compose --env-file /opt/misneach/.env -f /opt/misneach/docker-compose.prod.yml exec client node -e "fetch('http://127.0.0.1:8000/health').then(r=>{console.log(r.status);process.exit(r.ok?0:1)}).catch(()=>process.exit(1))"
+docker compose --env-file /opt/misneach/.env -f /opt/misneach/docker-compose.prod.yml exec client node -e "fetch('http://127.0.0.1:8000/courses/taster').then(async r=>{console.log(r.status);const j=await r.json();process.exit(r.ok&&j?.lesson?0:1)}).catch(()=>process.exit(1))"
 ```
+
+### Taster Content Verification
+
+`/courses/taster` is the public source for web taster content.
+
+- Endpoint smoke: `GET /courses/taster` should return `200` with `lesson`.
+- Web smoke: `GET /taster` should return `200` and render screens.
+
+If you need to pin a specific taster target in `courses`:
+
+- `COURSES_TASTER_COURSE_SLUG`
+- `COURSES_TASTER_LESSON_SLUG`
+
+Defaults use the first lesson in `cafe` when available.
 
 ## Rollback Runbook
 

--- a/docs/frontend-amplify.md
+++ b/docs/frontend-amplify.md
@@ -26,6 +26,10 @@ This runbook deploys `apps/web` to AWS Amplify Hosting.
 
 - Automatic: pushes to `main` that touch `apps/web/**` trigger [`web-amplify-deploy.yml`](../.github/workflows/web-amplify-deploy.yml).
 - Manual: run `Web Deploy (Amplify)` workflow and set branch input.
+- Deploy workflow smoke checks validate:
+  - `GET /taster`
+  - `GET /api/courses/taster`
+  - survey and waitlist API flows
 
 ## Notes
 

--- a/docs/single-entrypoint-roadmap.md
+++ b/docs/single-entrypoint-roadmap.md
@@ -36,6 +36,7 @@ Target:
 - All web integration traffic goes through `client`.
 - Public ingress policy exposes only intended entrypoints (`api-proxy` for API).
 - Staging and production smoke tests pass for waitlist/survey flows.
+- Staging and production smoke tests pass for taster endpoint/page (`/api/courses/taster`, `/taster`).
 
 ## Infrastructure Baseline
 


### PR DESCRIPTION
… updates

## Summary

-

## Linked Issue

Closes #47

## Deployment Metadata

- Deploy impact label: `deploy:frontend` | `deploy:backend` | `deploy:both` | `deploy:none`
- Environment label: `env:staging` | `env:prod`

## Documentation Impact

- [ ] Updated deployment docs (`docs/deployment.md`) if deploy/config behavior changed
- [ ] Updated architecture docs (`docs/architecture.md` or `docs/adr/*`) if service interaction/topology changed
- [ ] No architecture documentation impact
- [x] No documentation impact

## Validation

- [ ] Tests/build pass locally or in CI
- [ ] Rollout plan included (for risky changes)
- [ ] Rollback plan included (for risky changes)
