### PR TITLE
fix(web): read nest upstream env from /static/private for SSR

### DIFF
--- a/apps/web/src/lib/server/api.ts
+++ b/apps/web/src/lib/server/api.ts
@@ -1,9 +1,9 @@
 import type { RequestEvent } from '@sveltejs/kit';
-import { NEST_INTERNAL_URL, NEST_INTERNAL_URLS } from '$env/static/private';
+import { env } from '$env/dynamic/private';
 
 function resolveNestBaseUrls(): string[] {
-  const configured = (NEST_INTERNAL_URL || '').trim();
-  const configuredList = (NEST_INTERNAL_URLS || '')
+  const configured = (env.NEST_INTERNAL_URL || '').trim();
+  const configuredList = (env.NEST_INTERNAL_URLS || '')
     .split(',')
     .map((value) => value.trim())
     .filter(Boolean);
@@ -42,8 +42,8 @@ export async function nestFetch(
     if (event.locals.auth.role) {
       headers.set('x-user-role', event.locals.auth.role);
     }
-    if (process.env.INTERNAL_AUTH_SECRET) {
-      headers.set('x-internal-auth', process.env.INTERNAL_AUTH_SECRET);
+    if (env.INTERNAL_AUTH_SECRET) {
+      headers.set('x-internal-auth', env.INTERNAL_AUTH_SECRET);
     }
   }
 


### PR DESCRIPTION
## Summary

-

## Linked Issue

Closes #52 

## Deployment Metadata

- Deploy impact label: `deploy:frontend` | `deploy:backend` | `deploy:both` | `deploy:none`
- Environment label: `env:staging` | `env:prod`

## Documentation Impact

- [ ] Updated deployment docs (`docs/deployment.md`) if deploy/config behavior changed
- [ ] Updated architecture docs (`docs/architecture.md` or `docs/adr/*`) if service interaction/topology changed
- [ ] No architecture documentation impact
- [x] No documentation impact

## Validation

- [ ] Tests/build pass locally or in CI
- [ ] Rollout plan included (for risky changes)
- [ ] Rollback plan included (for risky changes)
