### PR TITLE
fix(app-web): use apiFetch for phrasebook update/delete/toggle proxy …

### DIFF
--- a/apps/app-web/src/routes/dashboard/phrasebook/+page.svelte
+++ b/apps/app-web/src/routes/dashboard/phrasebook/+page.svelte
@@ -268,7 +268,7 @@
 
     try {
       if (editingPhraseId != null) {
-        const res = await fetch(`/api/proxy/phrasebook/${editingPhraseId}`, {
+        const res = await apiFetch(`/api/proxy/phrasebook/${editingPhraseId}`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
@@ -353,7 +353,7 @@
     if (!confirmed) return;
 
     try {
-      const res = await fetch(`/api/proxy/phrasebook/${editingPhraseId}`, { method: 'DELETE' });
+      const res = await apiFetch(`/api/proxy/phrasebook/${editingPhraseId}`, { method: 'DELETE' });
       if (!res.ok) throw new Error(await readErrorMessage(res, 'Failed to delete phrase'));
       closePhraseModal();
       showToast('Phrase removed');
@@ -364,7 +364,7 @@
   }
 
   async function patchPhrase(id: number | string, patch: Partial<Phrase>) {
-    const res = await fetch(`/api/proxy/phrasebook/${id}`, {
+    const res = await apiFetch(`/api/proxy/phrasebook/${id}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(patch)


### PR DESCRIPTION
…calls in token mode

## Summary

-

## Linked Issue

Closes #98 

## Deployment Metadata

- Deploy impact label: `deploy:frontend`
- Environment label: `env:staging` | `env:prod`

## Documentation Impact

- [ ] Updated deployment docs (`docs/deployment.md`) if deploy/config behavior changed
- [ ] Updated architecture docs (`docs/architecture.md` or `docs/adr/*`) if service interaction/topology changed
- [ ] No architecture documentation impact
- [x] No documentation impact

## Validation

- [ ] Tests/build pass locally or in CI
- [ ] Rollout plan included (for risky changes)
- [ ] Rollback plan included (for risky changes)
