### PR TITLE
fix(phrasebook): normalize manual/course source attribution and add l…

### DIFF
--- a/apps/client/src/phrasebook/phrasebook.service.ts
+++ b/apps/client/src/phrasebook/phrasebook.service.ts
@@ -33,6 +33,37 @@ export class PhrasebookService {
     private readonly authService: AuthService,
   ) {}
 
+  private normalizeSource(source: string | undefined | null): 'manual' | 'course' {
+    const normalized = String(source || '').trim().toLowerCase();
+    if (!normalized) return 'manual';
+
+    if (
+      normalized === 'manual' ||
+      normalized === 'own' ||
+      normalized === 'user' ||
+      normalized === 'user_added' ||
+      normalized === 'custom' ||
+      normalized === 'personal' ||
+      normalized === 'direct_input' ||
+      normalized === 'manual_input'
+    ) {
+      return 'manual';
+    }
+
+    if (
+      normalized === 'course' ||
+      normalized === 'nlp' ||
+      normalized === 'lesson' ||
+      normalized === 'course_phrase' ||
+      normalized === 'lexicon' ||
+      normalized === 'import'
+    ) {
+      return 'course';
+    }
+
+    return 'manual';
+  }
+
   // ---------------- SSE ----------------
 
   registerSseClient(clientId: string, res: any) {
@@ -87,10 +118,7 @@ export class PhrasebookService {
     const autoTranslation =
       typeof body?.autoTranslate === 'boolean' ? body.autoTranslate : undefined;
 
-    const source =
-      typeof body?.source === 'string' && body.source.trim().length > 0
-        ? body.source.trim()
-        : 'own';
+    const source = this.normalizeSource(body?.source);
 
     const res = await fetch(
       `${this.phrasebookUrl}/phrases?clientId=${encodeURIComponent(clientId)}`,

--- a/apps/phrasebook/src/migrations/1769875200000-NormalizePhraseSourceAttribution.ts
+++ b/apps/phrasebook/src/migrations/1769875200000-NormalizePhraseSourceAttribution.ts
@@ -1,0 +1,51 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class NormalizePhraseSourceAttribution1769875200000
+  implements MigrationInterface
+{
+  name = 'NormalizePhraseSourceAttribution1769875200000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      UPDATE phrases
+      SET source = 'manual'
+      WHERE LOWER(TRIM(source)) IN (
+        'manual',
+        'own',
+        'user',
+        'user_added',
+        'custom',
+        'personal',
+        'direct_input',
+        'manual_input'
+      )
+    `);
+
+    await queryRunner.query(`
+      UPDATE phrases
+      SET source = 'course'
+      WHERE LOWER(TRIM(source)) IN (
+        'course',
+        'nlp',
+        'lesson',
+        'course_phrase',
+        'lexicon',
+        'import'
+      )
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      UPDATE phrases
+      SET source = 'own'
+      WHERE source = 'manual'
+    `);
+
+    await queryRunner.query(`
+      UPDATE phrases
+      SET source = 'nlp'
+      WHERE source = 'course'
+    `);
+  }
+}

--- a/apps/phrasebook/src/phrasebook/phrasebook.service.ts
+++ b/apps/phrasebook/src/phrasebook/phrasebook.service.ts
@@ -31,6 +31,43 @@ export class PhrasebookService {
       .trim();
   }
 
+  private normalizeSource(
+    source: string | undefined | null,
+    fallback: 'manual' | 'course' = 'manual',
+  ): 'manual' | 'course' {
+    const normalized = String(source || '')
+      .trim()
+      .toLowerCase();
+
+    if (!normalized) return fallback;
+
+    if (
+      normalized === 'manual' ||
+      normalized === 'own' ||
+      normalized === 'user' ||
+      normalized === 'user_added' ||
+      normalized === 'custom' ||
+      normalized === 'personal' ||
+      normalized === 'direct_input' ||
+      normalized === 'manual_input'
+    ) {
+      return 'manual';
+    }
+
+    if (
+      normalized === 'course' ||
+      normalized === 'nlp' ||
+      normalized === 'lesson' ||
+      normalized === 'course_phrase' ||
+      normalized === 'lexicon' ||
+      normalized === 'import'
+    ) {
+      return 'course';
+    }
+
+    return fallback;
+  }
+
   // Fingerprint must be scoped by client to avoid cross-user collisions.
   private phraseFingerprint(clientId: string, normalizedText: string) {
     return createHash('sha256')
@@ -158,7 +195,7 @@ export class PhrasebookService {
       createdAt: new Date(),
       ...dto,
       text: normalizedText,
-      source: String(dto.source || 'own'),
+      source: this.normalizeSource(dto.source, 'manual'),
       inPractice: Boolean(dto.inPractice),
       inFlashcards: Boolean(dto.inFlashcards),
     });
@@ -241,6 +278,9 @@ export class PhrasebookService {
     if (!phrase) throw new NotFoundException(`Phrase ${id} not found`);
 
     Object.assign(phrase, dto);
+    if (typeof dto.source === 'string') {
+      phrase.source = this.normalizeSource(dto.source, 'manual');
+    }
     await this.phraseRepo.save(phrase);
 
     await this.emitStatementEvent('statement_updated', phrase, dto);
@@ -368,7 +408,7 @@ export class PhrasebookService {
     return {
       id: p.id,
       text: p.text,
-      source: p.source,
+      source: this.normalizeSource(p.source, 'course'),
       translation: p.translation,
       pronunciation: p.pronunciation,
       example: p.example,


### PR DESCRIPTION
…egacy source backfill migration

## Summary

-

## Linked Issue

Closes #123 

## Deployment Metadata

- Deploy impact label: `deploy:backend`
- Environment label: `env:staging` | `env:prod`

## Documentation Impact

- [ ] Updated deployment docs (`docs/deployment.md`) if deploy/config behavior changed
- [ ] Updated architecture docs (`docs/architecture.md` or `docs/adr/*`) if service interaction/topology changed
- [ ] No architecture documentation impact
- [x] No documentation impact

## Validation

- [ ] Tests/build pass locally or in CI
- [ ] Rollout plan included (for risky changes)
- [ ] Rollback plan included (for risky changes)
