### PR TITLE
fix(phrasebook): support enter key submit in add-phrase modal

### DIFF
--- a/apps/app-web/src/routes/dashboard/phrasebook/+page.svelte
+++ b/apps/app-web/src/routes/dashboard/phrasebook/+page.svelte
@@ -981,7 +981,10 @@
     tabindex="-1"
     role="button"
   >
-    <div class="modal-sheet">
+    <form class="modal-sheet" onsubmit={(event) => {
+      event.preventDefault();
+      void savePhrase();
+    }}>
       <div class="modal-drag"></div>
       <h2 class="modal-title">{editingPhraseId != null ? 'Edit phrase' : 'Add a phrase'}</h2>
       <p class="modal-sub">{editingPhraseId != null ? 'Update the Irish, translation, pronunciation or notes.' : 'Save a phrase to your phrasebook. You can annotate it and route it to practice or flashcards.'}</p>
@@ -1090,10 +1093,10 @@
 
       <div class="modal-actions">
         {#if editingPhraseId != null}
-          <button class="btn-delete" onclick={deletePhrase}>Delete phrase</button>
+          <button type="button" class="btn-delete" onclick={deletePhrase}>Delete phrase</button>
         {/if}
-        <button class="btn-cancel" onclick={closePhraseModal}>Cancel</button>
-        <button class="btn-confirm" onclick={savePhrase} disabled={savingPhrase}>
+        <button type="button" class="btn-cancel" onclick={closePhraseModal}>Cancel</button>
+        <button type="submit" class="btn-confirm" disabled={savingPhrase}>
           {#if savingPhrase}
             Saving...
           {:else}
@@ -1101,7 +1104,7 @@
           {/if}
         </button>
       </div>
-    </div>
+    </form>
   </div>
 
   <div class={`toast ${toastVisible ? 'show' : ''}`}>


### PR DESCRIPTION
## Summary

-

## Linked Issue

Closes #129 

## Deployment Metadata

- Deploy impact label: `deploy:frontend` 
- Environment label: `env:staging` | `env:prod`

## Documentation Impact

- [ ] Updated deployment docs (`docs/deployment.md`) if deploy/config behavior changed
- [ ] Updated architecture docs (`docs/architecture.md` or `docs/adr/*`) if service interaction/topology changed
- [ ] No architecture documentation impact
- [x] No documentation impact

## Validation

- [ ] Tests/build pass locally or in CI
- [ ] Rollout plan included (for risky changes)
- [ ] Rollback plan included (for risky changes)
