### PR TITLE
docs(monorepo): add naming conventions for apps, services, and packages

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ This repository keeps operational and engineering documentation versioned with c
 - [Deployment and Operations](./deployment.md)
 - [Project Management (GitHub)](./project-management.md)
 - [System Architecture](./architecture.md)
+- [Naming Conventions](./naming-conventions.md)
 - [Repo Structure Roadmap](./repo-structure-roadmap.md)
 - [Shared Service Contract Audit](./shared-service-contracts.md)
 - [Single Entrypoint Roadmap](./single-entrypoint-roadmap.md)

--- a/docs/naming-conventions.md
+++ b/docs/naming-conventions.md
@@ -1,0 +1,194 @@
+# Naming Conventions
+
+This note defines naming rules for `apps/`, `services/`, and `packages/`, identifies the current inconsistencies in the repository, and scopes the follow-up rename work that would be needed to make the naming fully uniform.
+
+## Goal
+
+Use names that communicate role first and product second:
+
+- top-level directory names should reveal whether something is an application, service, or shared package
+- frontend app names should use product-facing names
+- backend service names should use domain/service names
+- shared package names should use scoped import names
+
+## Rules
+
+## `apps/`
+
+Use `kebab-case`.
+
+Pattern:
+
+- product apps: `<product>-<surface>`
+- role-specific apps: `<role>-web`
+- campaign or event apps: `<theme>` or `<product>-<theme>` when product ownership needs to be explicit
+
+Examples:
+
+- `misneach-web`
+- `misneach-mobile`
+- `cleachtadh-web`
+- `cleachtadh-mobile`
+- `admin-web`
+
+When to use product names:
+
+- use product names for anything user-facing
+- prefer `misneach` and `cleachtadh` over technical names like `web` or `app-web`
+
+When not to use domain names:
+
+- do not name apps after deployment hosts such as `misneach-ie-web`
+- domains can change; product identity is more stable
+
+## `services/`
+
+Use `kebab-case`.
+
+Pattern:
+
+- use the business/domain noun for the runtime service
+- keep names product-agnostic where the service is shared by multiple products
+
+Examples:
+
+- `client`
+- `phrasebook`
+- `practice`
+- `courses`
+- `discounts`
+- `waitlist`
+
+Guidelines:
+
+- prefer short domain names over transport-oriented names
+- avoid embedding frontend product names in shared backend services unless the service is truly product-specific
+
+## `packages/`
+
+Use `kebab-case` for directories and scoped names for package ids.
+
+Pattern:
+
+- directory: `<capability>`
+- package name: `@misneach/<capability>`
+
+Examples:
+
+- `packages/ui` -> `@misneach/ui`
+- `packages/auth` -> `@misneach/auth`
+- `packages/analytics` -> `@misneach/analytics`
+- `packages/email` -> `@misneach/email`
+
+Guidelines:
+
+- use the scope for import identity, not product ownership of runtime behavior
+- only place code in `packages/` if it is intentionally shared
+
+## Product Name vs Domain Name
+
+Use product names in:
+
+- app directory names
+- visible product copy
+- workspace names
+- package names when the package scope is organizational rather than product-specific runtime ownership
+
+Use domain/service names in:
+
+- backend runtime service names
+- internal architectural docs
+- API ownership boundaries
+
+Do not use deployment hostnames as canonical code identifiers.
+
+## Current State
+
+The repository mostly follows the intended pattern now:
+
+### Apps
+
+- `admin-web`
+- `cleachtadh-mobile`
+- `cleachtadh-web`
+- `irish-week`
+- `misneach-mobile`
+- `misneach-web`
+
+### Services
+
+- `business`
+- `challenges`
+- `client`
+- `courses`
+- `discounts`
+- `flashcards`
+- `focus`
+- `lexicon`
+- `payment`
+- `phrasebook`
+- `practice`
+- `translation/translation-connector`
+- `waitlist`
+
+### Packages
+
+- `@misneach/analytics`
+- `@misneach/auth`
+- `@misneach/email`
+- `@misneach/ui`
+
+## Current Inconsistencies
+
+1. `apps/irish-week`
+   - directory name is generic event naming
+   - workspace name is `misneach-irish-week`
+   - this is understandable, but not perfectly aligned
+
+2. `services/translation/translation-connector`
+   - nested path differs from the flatter service layout
+   - package name `translation-connector` is more integration-oriented than domain-oriented
+
+3. `client`
+   - service name is infrastructure/gateway-oriented rather than domain-oriented
+   - this is acceptable if it remains the public API gateway abstraction
+   - if it evolves into a stricter BFF/API platform layer, a future rename to something like `api-gateway` could be considered, but that is not recommended now
+
+4. top-level `nlp/`
+   - still outside `services/`
+   - structural inconsistency more than naming inconsistency
+
+## Follow-Up Rename Work
+
+These are the only follow-up naming changes worth considering from the current state:
+
+1. Decide whether `apps/irish-week` should become `apps/misneach-irish-week`
+   - benefit: matches workspace/package identity
+   - cost: low-to-medium rename churn for a limited-value cleanup
+
+2. Decide whether `services/translation/translation-connector` should become one of:
+   - `services/translator`
+   - `services/translation-connector`
+   - keep current nested structure intentionally
+
+3. Move `nlp/` to `services/nlp`
+   - this is primarily structural, but it also completes the naming model
+
+## Recommendation
+
+Adopt these as the repository rules going forward:
+
+1. new frontend applications must be named `<product>-web`, `<product>-mobile`, or another product-first `kebab-case` variant
+2. new backend runtimes must use short domain/service names under `services/`
+3. new shared packages must use `@misneach/<name>`
+4. do not rename stable services only for theoretical elegance unless there is a concrete clarity or ownership gain
+
+## Practical Conclusion
+
+The naming model is already good enough to standardize without more immediate churn.
+
+The only worthwhile follow-up changes are:
+
+1. move `nlp/` under `services/`
+2. make an explicit decision on `irish-week`
+3. make an explicit decision on `translation-connector`

--- a/docs/repo-structure-roadmap.md
+++ b/docs/repo-structure-roadmap.md
@@ -191,3 +191,5 @@ Frontend-only workflows remain correctly scoped to application entries under `ap
 - If it is a deployable user-facing application, place it under `apps/`.
 - If it is a deployable backend/runtime service, place it under `services/`.
 - If it is imported shared code rather than a runtime, place it under `packages/` or `libs/` according to the existing shared-code strategy.
+
+Related policy: [Naming Conventions](./naming-conventions.md)


### PR DESCRIPTION
## Summary

-

## Linked Issue

Closes #189 

## Deployment Metadata

- Deploy impact label: `deploy:none`
- Environment label: `env:staging` | `env:prod`

## Documentation Impact

- [x] Updated deployment docs (`docs/deployment.md`) if deploy/config behavior changed
- [x] Updated architecture docs (`docs/architecture.md` or `docs/adr/*`) if service interaction/topology changed
- [ ] No architecture documentation impact
- [ ] No documentation impact

## Validation

- [ ] Tests/build pass locally or in CI
- [ ] Rollout plan included (for risky changes)
- [ ] Rollback plan included (for risky changes)
