### PR TITLE
docs(auth): add runbook and auth observability guardrails

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ This repository keeps operational and engineering documentation versioned with c
 - [Naming Conventions](./naming-conventions.md)
 - [Repo Structure Roadmap](./repo-structure-roadmap.md)
 - [Shared Service Contract Audit](./shared-service-contracts.md)
+- [Auth Runbook](./auth-runbook.md)
 - [Single Entrypoint Roadmap](./single-entrypoint-roadmap.md)
 - [Mobile Auth Token Contract](./mobile-auth-token-contract.md)
 - [Mobile Capacitor Bootstrap](./mobile-capacitor-bootstrap.md)

--- a/docs/auth-runbook.md
+++ b/docs/auth-runbook.md
@@ -1,0 +1,164 @@
+# Auth Runbook
+
+This runbook covers rollout verification, observability, and rollback guardrails for the shared backend-owned token auth flow used by `misneach-web` and `cleachtadh-web`.
+
+## Scope
+
+- Backend auth owner: `services/client/src/auth/*`
+- Web entrypoints:
+  - `apps/misneach-web`
+  - `apps/cleachtadh-web`
+- Primary user-visible flows:
+  - request magic link
+  - verify magic link
+  - fetch `/auth/me`
+  - refresh token
+  - logout
+
+## Current Auth Contract
+
+- Magic-link initiation: `POST /auth/login` with `{ email, appBaseUrl? }`
+- Magic-link verification to token pair: `POST /auth/login` with `{ email, token }`
+- Current user: `GET /auth/me` with bearer token or compatibility session
+- Refresh: `POST /auth/refresh`
+- Logout: `POST /auth/logout`
+
+Reference docs:
+
+- [Mobile Auth Token Contract](./mobile-auth-token-contract.md)
+- [Shared Service Contract Audit](./shared-service-contracts.md)
+
+## Verification Checklist
+
+Run these checks after deploy to staging or production.
+
+### 1. Request a magic link
+
+- Open `misneach-web` login page.
+- Submit a known test email.
+- Confirm UI returns a pending/sent state.
+- Confirm backend logs include:
+  - `magic_link_generated`
+  - `magic_link_delivered` or `magic_link_delivery_logged`
+  - `auth_login_pending`
+
+### 2. Verify the magic link
+
+- Open the received link from the email.
+- Confirm redirect reaches:
+  - `/dashboard` for completed users, or
+  - `/auth/signup` for incomplete learner signup
+- Confirm backend logs include:
+  - `magic_link_verify_succeeded`
+  - `auth_login_succeeded`
+
+### 3. Verify `/auth/me`
+
+- From the web app after login, confirm authenticated pages load normally.
+- Spot check `GET /auth/me` through browser devtools or curl with a bearer token.
+- Confirm no unexpected spike of:
+  - `auth_me_unauthenticated mode=bearer`
+  - `auth_me_unauthenticated mode=session`
+
+### 4. Verify refresh
+
+- Keep a logged-in session active long enough to trigger refresh logic, or trigger it manually with a stored refresh token.
+- Confirm backend logs include:
+  - `auth_refresh_succeeded`
+- Confirm no repeated:
+  - `auth_refresh_failed`
+
+### 5. Verify logout
+
+- Trigger logout from each web app.
+- Confirm the next authenticated request returns logged-out state.
+- Confirm backend logs include:
+  - `auth_logout_requested`
+
+## Observability
+
+The current implementation uses grep-friendly structured log events rather than a separate metrics pipeline.
+
+### Auth Log Events
+
+- `magic_link_generated`
+- `magic_link_delivered`
+- `magic_link_delivery_logged`
+- `magic_link_verify_succeeded`
+- `magic_link_verify_failed`
+- `auth_login_pending`
+- `auth_login_succeeded`
+- `auth_login_failed`
+- `auth_refresh_succeeded`
+- `auth_refresh_failed`
+- `auth_me_unauthenticated`
+- `auth_logout_requested`
+
+### Suggested Log Queries
+
+Use container logs for the `client` service.
+
+```bash
+docker compose --env-file /opt/misneach/.env -f /opt/misneach/docker-compose.prod.yml logs client --since=30m | rg "magic_link_|auth_login_|auth_refresh_|auth_me_|auth_logout_"
+```
+
+Failure-focused query:
+
+```bash
+docker compose --env-file /opt/misneach/.env -f /opt/misneach/docker-compose.prod.yml logs client --since=30m | rg "magic_link_verify_failed|auth_login_failed|auth_refresh_failed|auth_me_unauthenticated"
+```
+
+### What to Watch
+
+- Increase in `magic_link_verify_failed cause=token_invalid`
+- Increase in `magic_link_verify_failed cause=token_expired`
+- Increase in `auth_refresh_failed`
+- Sustained `auth_me_unauthenticated` events after a deployment
+- Missing `magic_link_delivered` after `magic_link_generated`
+
+## Fast Rollback Procedure
+
+If auth regressions are user-visible:
+
+1. Identify the last known good backend image tag for `client`.
+2. Set `IMAGE_TAG` in the deployment environment to that SHA.
+3. Redeploy the production compose stack.
+4. Re-run:
+   - magic-link request
+   - magic-link verify
+   - `/auth/me`
+   - logout
+5. If frontend behavior is still broken, revert the affected web image(s) as well.
+
+Reference operational commands:
+
+```bash
+docker compose --env-file /opt/misneach/.env -f /opt/misneach/docker-compose.prod.yml pull client
+docker compose --env-file /opt/misneach/.env -f /opt/misneach/docker-compose.prod.yml up -d client api-proxy cleachtadh-web
+docker compose --env-file /opt/misneach/.env -f /opt/misneach/docker-compose.prod.yml logs client --tail=200
+```
+
+## Staging Dry-Run Record
+
+Complete this before production rollout:
+
+- Date:
+- Branch / PR:
+- Environment: `staging`
+- Tester:
+
+Checklist:
+
+- Magic link requested successfully on `misneach-web`
+- Magic link requested successfully on `cleachtadh-web`
+- Verify link completed successfully on `misneach-web`
+- Verify link completed successfully on `cleachtadh-web`
+- `/auth/me` returned authenticated user after login
+- Refresh completed successfully
+- Logout completed successfully
+- Rollback procedure reviewed and image tag identified
+
+Result:
+
+- Pass / Fail
+- Notes:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -32,6 +32,7 @@ Relevant workflows:
 - [frontend-builds.yml](../.github/workflows/frontend-builds.yml)
 - [web-amplify-deploy.yml](../.github/workflows/web-amplify-deploy.yml)
 - [Frontend Amplify Runbook](./frontend-amplify.md)
+- [Auth Runbook](./auth-runbook.md)
 
 ## Environment Variable Strategy
 

--- a/services/client/src/auth/auth.controller.ts
+++ b/services/client/src/auth/auth.controller.ts
@@ -94,6 +94,7 @@ export class AuthController {
         email,
         this.resolveRequestedAppBaseUrl(req, body?.appBaseUrl),
       );
+      this.logger.log(`auth_login_pending email=${email}`);
       return res.status(HttpStatus.OK).json({
         ok: true,
         status: 'pending_verification',
@@ -101,8 +102,17 @@ export class AuthController {
       });
     }
 
-    const tokenPair = await this.authService.issueTokenPairFromMagicLink(email, token);
-    return res.status(HttpStatus.OK).json(tokenPair);
+    try {
+      const tokenPair = await this.authService.issueTokenPairFromMagicLink(email, token);
+      this.logger.log(
+        `auth_login_succeeded userId=${tokenPair.user.id} clientId=${tokenPair.user.clientId} signupComplete=${tokenPair.user.signupComplete}`,
+      );
+      return res.status(HttpStatus.OK).json(tokenPair);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.warn(`auth_login_failed email=${email} cause=${message}`);
+      throw err;
+    }
   }
 
   private resolveRequestedAppBaseUrl(
@@ -131,14 +141,19 @@ export class AuthController {
   async refresh(@Body() body: { refreshToken: string }, @Res() res: Response) {
     const refreshToken = String(body?.refreshToken || '').trim();
     if (!refreshToken) {
+      this.logger.warn('auth_refresh_failed cause=missing_refresh_token');
       return res.status(HttpStatus.BAD_REQUEST).json({ error: 'refreshToken is required' });
     }
 
     try {
       const tokenPair = await this.authService.refreshTokenPair(refreshToken);
+      this.logger.log(
+        `auth_refresh_succeeded userId=${tokenPair.user.id} clientId=${tokenPair.user.clientId}`,
+      );
       return res.status(HttpStatus.OK).json(tokenPair);
     } catch (err) {
       if (err instanceof UnauthorizedException) {
+        this.logger.warn(`auth_refresh_failed cause=${err.message}`);
         return res.status(HttpStatus.UNAUTHORIZED).json({ error: err.message });
       }
       throw err;
@@ -281,6 +296,7 @@ export class AuthController {
           },
         };
       } catch {
+        this.logger.warn('auth_me_unauthenticated mode=bearer');
         return { loggedIn: false, user: null };
       }
     }
@@ -294,12 +310,13 @@ export class AuthController {
           clientId: user.clientId,
           email: user.email,
           role: user.role,
-          signupComplete: user.hasCompletedSignup,
-        },
-      };
-    } catch {
-      return { loggedIn: false, user: null };
-    }
+            signupComplete: user.hasCompletedSignup,
+          },
+        };
+      } catch {
+        this.logger.warn('auth_me_unauthenticated mode=session');
+        return { loggedIn: false, user: null };
+      }
   }
 
   /**
@@ -307,6 +324,7 @@ export class AuthController {
    */
   @Post('logout')
   logout(@Body() _body: { refreshToken?: string }, @Res() res: Response) {
+    this.logger.log('auth_logout_requested');
     res.clearCookie(AUTH_COOKIE, {
       path: '/',
       httpOnly: true,

--- a/services/client/src/auth/auth.service.ts
+++ b/services/client/src/auth/auth.service.ts
@@ -335,6 +335,7 @@ export class AuthService {
 
   async handleMagicLink(email: string, appBaseUrl?: string): Promise<{ message: string }> {
     if (!email) {
+      this.logger.warn('magic_link_rejected cause=missing_email');
       throw new Error('Email is required');
     }
 
@@ -366,6 +367,9 @@ export class AuthService {
     const appUrl = this.resolveMagicLinkAppUrl(appBaseUrl);
     const verifyUrl = `${appUrl}/auth/verify-request?token=${token}&email=${email}`;
     const brand = this.resolveAppBrand(appUrl);
+    this.logger.log(
+      `magic_link_generated userId=${user.id} clientId=${user.clientId} appUrl=${appUrl} deliveryMode=${this.config.get<string>('EMAIL_DELIVERY', 'send')}`,
+    );
 
     const userLang = user.languageSettings?.[0]?.firstLanguage || 'en';
     const translationFactory = translations[userLang] || translations.en;
@@ -393,6 +397,7 @@ export class AuthService {
       console.log('To:', email);
       console.log('Verify URL:', verifyUrl);
       console.log('———————————————');
+      this.logger.log(`magic_link_delivery_logged userId=${user.id} clientId=${user.clientId}`);
 
       return {
         message: 'Magic link generated (email delivery disabled)',
@@ -405,12 +410,14 @@ export class AuthService {
       subject: selectedTranslations.subject,
       html: emailHtml,
     });
+    this.logger.log(`magic_link_delivered userId=${user.id} clientId=${user.clientId}`);
 
     return { message: 'Magic link sent!' };
   }
 
   async verifyMagicLinkToken(token: string, email: string): Promise<User> {
     if (!token || !email) {
+      this.logger.warn('magic_link_verify_failed cause=invalid_request');
       throw new BadRequestException('Invalid request');
     }
 
@@ -421,24 +428,35 @@ export class AuthService {
       .orderBy('magicLink.createdAt', 'DESC')
       .getOne();
 
-    if (!magicLink) throw new NotFoundException('Token not found');
+    if (!magicLink) {
+      this.logger.warn(`magic_link_verify_failed email=${email} cause=token_not_found`);
+      throw new NotFoundException('Token not found');
+    }
 
     if (new Date(magicLink.expiresAt) < new Date()) {
+      this.logger.warn(`magic_link_verify_failed email=${email} cause=token_expired`);
       throw new UnauthorizedException('Token expired');
     }
 
     const isValid = await bcrypt.compare(token, magicLink.token);
-    if (!isValid) throw new UnauthorizedException('Invalid token');
+    if (!isValid) {
+      this.logger.warn(`magic_link_verify_failed email=${email} cause=token_invalid`);
+      throw new UnauthorizedException('Invalid token');
+    }
 
     const user = await this.userRepo.findOne({
       where: { email },
       relations: ['languageSettings'],
     });
     if (!user?.clientId) {
+      this.logger.error(`magic_link_verify_failed email=${email} cause=missing_client_id`);
       throw new InternalServerErrorException('Client ID missing');
     }
 
     await this.ensureDefaultLanguageSettings(user);
+    this.logger.log(
+      `magic_link_verify_succeeded userId=${user.id} clientId=${user.clientId} signupComplete=${user.hasCompletedSignup}`,
+    );
 
     return user;
   }


### PR DESCRIPTION
## Summary

-

## Linked Issue

Closes #9 

## Deployment Metadata

- Deploy impact label:  `deploy:backend`
- Environment label: `env:staging` | `env:prod`

## Documentation Impact

- [x] Updated deployment docs (`docs/deployment.md`) if deploy/config behavior changed
- [x] Updated architecture docs (`docs/architecture.md` or `docs/adr/*`) if service interaction/topology changed
- [ ] No architecture documentation impact
- [ ] No documentation impact

## Validation

- [ ] Tests/build pass locally or in CI
- [ ] Rollout plan included (for risky changes)
- [ ] Rollback plan included (for risky changes)
