### PR TITLE
infra: add automated deployment process for serverless stack

### DIFF
--- a/.github/workflows/public-api-deploy.yml
+++ b/.github/workflows/public-api-deploy.yml
@@ -1,0 +1,106 @@
+name: Public API Deploy
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/public-api-deploy.yml'
+      - 'infra/aws/**'
+      - 'packages/public-flows/**'
+      - 'services/public-api/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig.base.json'
+  workflow_dispatch:
+
+env:
+  NODE_VERSION: 20
+  STACK_NAME: decyphr-prod-public-api
+
+permissions:
+  contents: read
+
+concurrency:
+  group: public-api-prod
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy production public API
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Validate required secrets
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: |
+          set -euo pipefail
+          test -n "$AWS_REGION"
+          test -n "$AWS_ACCESS_KEY_ID"
+          test -n "$AWS_SECRET_ACCESS_KEY"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Test shared public-flow logic
+        run: npm run test --workspace @misneach/public-flows
+
+      - name: Test public API Lambdas
+        run: npm run test --workspace public-api
+
+      - name: Build public API Lambdas
+        run: npm run build --workspace public-api
+
+      - name: CDK synth
+        run: npm run synth --workspace @decyphr/aws-infra
+
+      - name: Deploy CDK stack
+        run: npm run deploy --workspace @decyphr/aws-infra -- --require-approval never --outputs-file ../../cdk-public-api-outputs.json
+
+      - name: Publish deployment outputs
+        env:
+          OUTPUTS_FILE: cdk-public-api-outputs.json
+        run: |
+          set -euo pipefail
+          test -f "$OUTPUTS_FILE"
+          PUBLIC_API_URL="$(node -e "const outputs=require('./cdk-public-api-outputs.json'); const stack=outputs[process.env.STACK_NAME] || {}; console.log(stack.PublicApiUrl || '')")"
+          test -n "$PUBLIC_API_URL"
+          echo "Public API URL: $PUBLIC_API_URL"
+          {
+            echo "## Public API deployment"
+            echo ""
+            echo "- Stack: \`$STACK_NAME\`"
+            echo "- Public API URL: $PUBLIC_API_URL"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Print CloudFormation events on failure
+        if: failure()
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+        run: |
+          set +e
+          echo "Recent CloudFormation events for $STACK_NAME"
+          aws cloudformation describe-stack-events \
+            --stack-name "$STACK_NAME" \
+            --region "$AWS_REGION" \
+            --max-items 25 \
+            --query 'StackEvents[].{Time:Timestamp,Status:ResourceStatus,Type:ResourceType,LogicalId:LogicalResourceId,Reason:ResourceStatusReason}' \
+            --output table

--- a/.github/workflows/public-api-pr.yml
+++ b/.github/workflows/public-api-pr.yml
@@ -1,0 +1,46 @@
+name: Public API PR
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/public-api-pr.yml'
+      - '.github/workflows/public-api-deploy.yml'
+      - 'infra/aws/**'
+      - 'packages/public-flows/**'
+      - 'services/public-api/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig.base.json'
+  workflow_dispatch:
+
+env:
+  NODE_VERSION: 20
+
+jobs:
+  validate:
+    name: Test and synth
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Test shared public-flow logic
+        run: npm run test --workspace @misneach/public-flows
+
+      - name: Test public API Lambdas
+        run: npm run test --workspace public-api
+
+      - name: Build public API Lambdas
+        run: npm run build --workspace public-api
+
+      - name: CDK synth
+        run: npm run synth --workspace @decyphr/aws-infra

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -104,6 +104,53 @@ Deploy the stack:
 npm run deploy --workspace @decyphr/aws-infra
 ```
 
+### Public API CI/CD
+
+Public API infrastructure deploys through dedicated GitHub Actions workflows:
+
+- `Public API PR` runs on pull requests that touch `infra/aws`, `services/public-api`, `packages/public-flows`, workspace metadata, or the workflow files. It installs dependencies, runs public-flow tests, runs public API Lambda tests/build, and runs CDK synth.
+- `Public API Deploy` runs on pushes to `main` for the same paths and can also be run manually with `workflow_dispatch`. It repeats the validation steps, deploys `decyphr-prod-public-api`, and writes the `PublicApiUrl` output to the workflow summary.
+
+Required GitHub repository or `production` environment secrets:
+
+```txt
+AWS_REGION
+AWS_ACCESS_KEY_ID
+AWS_SECRET_ACCESS_KEY
+```
+
+Manual production deploy:
+
+```bash
+npm ci
+npm run synth --workspace @decyphr/aws-infra
+npm run deploy --workspace @decyphr/aws-infra -- --require-approval never --outputs-file ../../cdk-public-api-outputs.json
+```
+
+Rollback:
+
+1. Revert the PR or commit that introduced the bad stack/Lambda change.
+2. Merge the revert to `main`.
+3. Confirm `Public API Deploy` completes and reports the expected `PublicApiUrl`.
+
+Manual rollback to a known-good commit:
+
+```bash
+git checkout <known-good-sha>
+npm ci
+npm run deploy --workspace @decyphr/aws-infra -- --require-approval never
+```
+
+Failed deploy diagnostics:
+
+```bash
+aws cloudformation describe-stack-events \
+  --stack-name decyphr-prod-public-api \
+  --region <region> \
+  --max-items 25 \
+  --output table
+```
+
 Run the same public API infrastructure locally with Floci:
 
 ```bash

--- a/infra/aws/README.md
+++ b/infra/aws/README.md
@@ -52,6 +52,51 @@ Deploy to AWS:
 npm run deploy --workspace @decyphr/aws-infra
 ```
 
+Deploy and write CDK outputs to a file:
+
+```bash
+npm run deploy --workspace @decyphr/aws-infra -- --require-approval never --outputs-file ../../cdk-public-api-outputs.json
+```
+
+## CI Deployment
+
+Public API infrastructure has separate validation and deployment workflows:
+
+- `.github/workflows/public-api-pr.yml` runs on pull requests and validates install, public-flow tests, public API Lambda tests/build, and CDK synth.
+- `.github/workflows/public-api-deploy.yml` runs on pushes to `main` and deploys `decyphr-prod-public-api`.
+
+Required repository/environment secrets:
+
+```txt
+AWS_REGION
+AWS_ACCESS_KEY_ID
+AWS_SECRET_ACCESS_KEY
+```
+
+The deploy workflow writes the `PublicApiUrl` stack output to the GitHub Actions step summary. Use that value for `WAITLIST_API_URL` and `SURVEYS_API_URL` in `misneach-web`.
+
+## Rollback
+
+To roll back a bad public API deploy, revert the PR that changed the stack or Lambda code and merge that revert to `main`; the deploy workflow will redeploy the previous desired state.
+
+Manual rollback to a known-good commit is also possible:
+
+```bash
+git checkout <known-good-sha>
+npm ci
+npm run deploy --workspace @decyphr/aws-infra -- --require-approval never
+```
+
+If a deployment fails, inspect the CloudFormation events:
+
+```bash
+aws cloudformation describe-stack-events \
+  --stack-name decyphr-prod-public-api \
+  --region <region> \
+  --max-items 25 \
+  --output table
+```
+
 ## Local Floci
 
 Start local AWS services:


### PR DESCRIPTION
## Summary

-

## Linked Issue

Closes #222 

## Deployment Metadata

- Deploy impact label: `deploy:frontend` | `deploy:backend` | `deploy:both` | `deploy:none`
- Environment label: `env:staging` | `env:prod`

## Documentation Impact

- [ ] Updated deployment docs (`docs/deployment.md`) if deploy/config behavior changed
- [ ] Updated architecture docs (`docs/architecture.md` or `docs/adr/*`) if service interaction/topology changed
- [ ] No architecture documentation impact
- [ ] No documentation impact

## Validation

- [ ] Tests/build pass locally or in CI
- [ ] Rollout plan included (for risky changes)
- [ ] Rollback plan included (for risky changes)
