### PR TITLE
fix: keep nlp service internal in production compose

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -41,8 +41,8 @@ services:
   nlp:
     image: ${DOCKERHUB_NAMESPACE:?Set DOCKERHUB_NAMESPACE}/misneach-nlp:${IMAGE_TAG:-latest}
     restart: unless-stopped
-    ports:
-      - "8300:8300"
+    expose:
+      - "8300"
 
   lexicon:
     <<: *backend-common


### PR DESCRIPTION
## Summary

-

## Linked Issue

Closes #230

## Deployment Metadata

- Deploy impact label: `deploy:frontend` | `deploy:backend` | `deploy:both` | `deploy:none`
- Environment label: `env:staging` | `env:prod`

## Documentation Impact

- [ ] Updated deployment docs (`docs/deployment.md`) if deploy/config behavior changed
- [ ] Updated architecture docs (`docs/architecture.md` or `docs/adr/*`) if service interaction/topology changed
- [x] No architecture documentation impact
- [x] No documentation impact

## Validation

- [ ] Tests/build pass locally or in CI
- [ ] Rollout plan included (for risky changes)
- [ ] Rollback plan included (for risky changes)
