### PR TITLE
ci: automate misneach web amplify deployment

### DIFF
--- a/.github/workflows/full-app-deploy.yml
+++ b/.github/workflows/full-app-deploy.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - '.github/workflows/full-app-deploy.yml'
       - '.github/workflows/backend-images-dockerhub.yml'
+      - '.github/workflows/web-amplify-deploy.yml'
+      - 'amplify.yml'
+      - 'apps/misneach-web/**'
       - 'deploy/**'
       - 'docker/**'
       - 'docker-compose.prod.yml'
@@ -61,6 +64,10 @@ jobs:
           PROD_SSH_HOST: ${{ secrets.PROD_SSH_HOST }}
           PROD_SSH_USER: ${{ secrets.PROD_SSH_USER }}
           PROD_SSH_KEY: ${{ secrets.PROD_SSH_KEY }}
+          AMPLIFY_WEB_APP_ID: ${{ secrets.AMPLIFY_WEB_APP_ID }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           set -euo pipefail
           test -n "$DOCKERHUB_USERNAME"
@@ -68,6 +75,10 @@ jobs:
           test -n "$PROD_SSH_HOST"
           test -n "$PROD_SSH_USER"
           test -n "$PROD_SSH_KEY"
+          test -n "$AMPLIFY_WEB_APP_ID"
+          test -n "$AWS_REGION"
+          test -n "$AWS_ACCESS_KEY_ID"
+          test -n "$AWS_SECRET_ACCESS_KEY"
 
       - name: Install dependencies
         run: npm ci
@@ -251,11 +262,24 @@ jobs:
             echo "- Compose path: \`$PROD_DEPLOY_PATH\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
+  deploy-misneach-web:
+    name: Deploy misneach-web to Amplify
+    needs: deploy-compose
+    uses: ./.github/workflows/web-amplify-deploy.yml
+    with:
+      branch: main
+    secrets:
+      AMPLIFY_WEB_APP_ID: ${{ secrets.AMPLIFY_WEB_APP_ID }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
   deployment-summary:
     name: Deployment summary
     needs:
       - publish-images
       - deploy-compose
+      - deploy-misneach-web
     if: always()
     runs-on: ubuntu-latest
     env:
@@ -274,17 +298,18 @@ jobs:
             echo "- Docker namespace: \`$IMAGE_NAMESPACE\`"
             echo "- Backend runtime image: \`misneach-backend-runtime:$GITHUB_SHA\`"
             echo "- NLP image: \`misneach-nlp:$GITHUB_SHA\`"
-            echo "- Misneach web: Amplify deploy temporarily disabled; deploy manually from Amplify"
+            echo "- Misneach web: ${{ needs.deploy-misneach-web.outputs.deploy_url || 'not reported' }}"
             echo "- Cleachtadh web: ${CLEACHTADH_WEB_URL:-set CLEACHTADH_WEB_URL repo variable}"
             echo "- Admin web: ${ADMIN_WEB_URL:-set ADMIN_WEB_URL repo variable}"
             echo ""
             echo "Results:"
             echo "- Image publish: \`${{ needs.publish-images.result }}\`"
             echo "- Compose deploy: \`${{ needs.deploy-compose.result }}\`"
-            echo "- Misneach web deploy: \`skipped\`"
+            echo "- Misneach web deploy: \`${{ needs.deploy-misneach-web.result }}\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
           if [ "${{ needs.publish-images.result }}" != "success" ] ||
-             [ "${{ needs.deploy-compose.result }}" != "success" ]; then
+             [ "${{ needs.deploy-compose.result }}" != "success" ] ||
+             [ "${{ needs.deploy-misneach-web.result }}" != "success" ]; then
             exit 1
           fi

--- a/.github/workflows/pr-metadata-guard.yml
+++ b/.github/workflows/pr-metadata-guard.yml
@@ -64,7 +64,7 @@ jobs:
                 return false;
               }
               if (
-                path.startsWith("apps/web/") ||
+                path.startsWith("apps/misneach-web/") ||
                 path.startsWith("apps/cleachtadh-web/") ||
                 path.startsWith("apps/admin-web/") ||
                 path.startsWith("apps/irish-week/")

--- a/.github/workflows/web-amplify-deploy.yml
+++ b/.github/workflows/web-amplify-deploy.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Validate required secrets
@@ -62,6 +62,64 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Configure Amplify app build settings
+        env:
+          APP_ID: ${{ secrets.AMPLIFY_WEB_APP_ID }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+        run: |
+          set -euo pipefail
+
+          BUILD_SPEC="$(cat amplify.yml)"
+          aws amplify get-app \
+            --app-id "$APP_ID" \
+            --region "$AWS_REGION" \
+            --query 'app.environmentVariables' \
+            --output json > /tmp/amplify-env.json
+
+          node <<'NODE'
+          const fs = require('node:fs');
+          const envPath = '/tmp/amplify-env.json';
+          const parsed = JSON.parse(fs.readFileSync(envPath, 'utf8') || '{}');
+          const env = parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+          env.AMPLIFY_MONOREPO_APP_ROOT = 'apps/misneach-web';
+          fs.writeFileSync('/tmp/amplify-env.updated.json', JSON.stringify(env));
+          NODE
+
+          aws amplify update-app \
+            --app-id "$APP_ID" \
+            --region "$AWS_REGION" \
+            --build-spec "$BUILD_SPEC" \
+            --environment-variables file:///tmp/amplify-env.updated.json \
+            >/dev/null
+
+          rm -f /tmp/amplify-env.json /tmp/amplify-env.updated.json
+
+          APP_ROOT="$(aws amplify get-app \
+            --app-id "$APP_ID" \
+            --region "$AWS_REGION" \
+            --query 'app.environmentVariables.AMPLIFY_MONOREPO_APP_ROOT' \
+            --output text)"
+
+          if [ "$APP_ROOT" != "apps/misneach-web" ]; then
+            echo "Amplify app root is '$APP_ROOT', expected 'apps/misneach-web'"
+            exit 1
+          fi
+
+          echo "Amplify app root configured: $APP_ROOT"
+
+      - name: Report Amplify IAM role
+        env:
+          APP_ID: ${{ secrets.AMPLIFY_WEB_APP_ID }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+        run: |
+          set -euo pipefail
+          ROLE_ARN="$(aws amplify get-app \
+            --app-id "$APP_ID" \
+            --region "$AWS_REGION" \
+            --query 'app.iamServiceRoleArn' \
+            --output text)"
+          echo "Amplify service role: ${ROLE_ARN:-not configured}"
 
       - name: Start Amplify branch deployment
         id: deploy
@@ -121,6 +179,13 @@ jobs:
 
             if [ "$status" = "FAILED" ] || [ "$status" = "CANCELLED" ]; then
               echo "Amplify deployment failed with status: $status"
+              aws amplify get-job \
+                --app-id "$APP_ID" \
+                --branch-name "$BRANCH_NAME" \
+                --job-id "$JOB_ID" \
+                --region "$AWS_REGION" \
+                --query 'job.steps[*].[stepName,status,logUrl]' \
+                --output table || true
               exit 1
             fi
 

--- a/amplify.yml
+++ b/amplify.yml
@@ -11,6 +11,12 @@ applications:
         build:
           commands:
             - rm -f apps/misneach-web/.env.production
+            - printf 'PUBLIC_API_BASE_URL=%s\n' "${PUBLIC_API_BASE_URL:-}" >> apps/misneach-web/.env.production
+            - printf 'PUBLIC_SURVEY_QR_BASE_URL=%s\n' "${PUBLIC_SURVEY_QR_BASE_URL:-}" >> apps/misneach-web/.env.production
+            - printf 'API_INTERNAL_URL=%s\n' "${API_INTERNAL_URL:-}" >> apps/misneach-web/.env.production
+            - printf 'API_INTERNAL_URLS=%s\n' "${API_INTERNAL_URLS:-}" >> apps/misneach-web/.env.production
+            - printf 'BUSINESS_INTERNAL_URL=%s\n' "${BUSINESS_INTERNAL_URL:-}" >> apps/misneach-web/.env.production
+            - printf 'BUSINESS_INTERNAL_URLS=%s\n' "${BUSINESS_INTERNAL_URLS:-}" >> apps/misneach-web/.env.production
             - printf 'NEST_INTERNAL_URL=%s\n' "${NEST_INTERNAL_URL:-}" >> apps/misneach-web/.env.production
             - printf 'NEST_INTERNAL_URLS=%s\n' "${NEST_INTERNAL_URLS:-}" >> apps/misneach-web/.env.production
             - printf 'CLIENT_API_URL=%s\n' "${CLIENT_API_URL:-}" >> apps/misneach-web/.env.production
@@ -27,7 +33,7 @@ applications:
             - npm run build --workspace misneach-web
             # Install runtime dependencies for the SSR compute bundle.
             - cd apps/misneach-web/build/compute/default
-            - npm i --omit=dev
+            - npm install --omit=dev
       artifacts:
         baseDirectory: apps/misneach-web/build
         files:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -19,9 +19,10 @@ Production application deployment has one automatic `main` path:
    - Shared runtime image: `misneach-backend-runtime:<sha>`
    - `misneach-nlp:<sha>` and `latest`
 4. It SSHes to the production host, uploads the production compose/proxy files, pulls images, and runs `docker compose up -d`.
-5. It writes a summary with image tags, frontend URLs, and deployment results.
+5. It deploys `misneach-web` through AWS Amplify Hosting.
+6. It writes a summary with image tags, frontend URLs, and deployment results.
 
-`misneach-web` Amplify deployment is temporarily kept out of the automatic full-app path while the Amplify app IAM role/build configuration is repaired. Deploy it manually from Amplify or with `web-amplify-deploy.yml` after that is fixed.
+`misneach-web` deploys from the monorepo app root `apps/misneach-web`. The workflow applies the repository [`amplify.yml`](../amplify.yml) build spec and `AMPLIFY_MONOREPO_APP_ROOT=apps/misneach-web` to the Amplify app before starting the branch release.
 
 `cleachtadh-web` and `admin-web` are frontend applications and are intentionally not deployed on the EC2 compose host. Deploy them to their frontend hosting targets instead of adding them to `docker-compose.prod.yml`.
 
@@ -51,6 +52,10 @@ PROD_SSH_KEY
 PROD_SSH_PORT              # optional; defaults to 22
 PROD_DEPLOY_PATH           # optional; defaults to /opt/misneach
 PROD_ENV_FILE              # optional; defaults to /opt/misneach/.env
+AMPLIFY_WEB_APP_ID
+AWS_REGION
+AWS_ACCESS_KEY_ID
+AWS_SECRET_ACCESS_KEY
 ```
 
 Optional repository variables used only in summaries:
@@ -59,6 +64,28 @@ Optional repository variables used only in summaries:
 CLEACHTADH_WEB_URL
 ADMIN_WEB_URL
 ```
+
+Required Amplify app environment variables for `misneach-web` production:
+
+```txt
+AMPLIFY_MONOREPO_APP_ROOT=apps/misneach-web
+PUBLIC_API_BASE_URL=https://api.<your-domain>
+PUBLIC_SURVEY_QR_BASE_URL=https://misneach.site
+API_INTERNAL_URL=https://api.<your-domain>
+API_INTERNAL_URLS=                 # optional comma-separated fallbacks
+PUBLIC_API_URL=https://<public-api-id>.execute-api.<region>.amazonaws.com
+WAITLIST_API_URL=                  # optional; falls back to PUBLIC_API_URL
+WAITLIST_API_URLS=                 # optional comma-separated fallbacks
+SURVEYS_API_URL=                   # optional; falls back to PUBLIC_API_URL
+SURVEYS_API_URLS=                  # optional comma-separated fallbacks
+BUSINESS_INTERNAL_URL=https://api.<your-domain>
+BUSINESS_INTERNAL_URLS=            # optional comma-separated fallbacks
+INTERNAL_AUTH_SECRET=<shared internal auth secret>
+APP_BASE_URL=https://misneach.site
+WEB_APP_URL=https://misneach.site
+```
+
+The AWS deploy user used by GitHub Actions must allow `amplify:GetApp`, `amplify:UpdateApp`, `amplify:StartJob`, `amplify:GetJob`, and `amplify:GetBranch` on the `misneach-web` Amplify app.
 
 Production host prerequisites:
 

--- a/docs/frontend-amplify.md
+++ b/docs/frontend-amplify.md
@@ -11,24 +11,40 @@ This runbook deploys `apps/misneach-web` to AWS Amplify Hosting.
 
 1. Create an Amplify app and connect this GitHub repository. SSR deploys require a connected repository app; disconnected/manual-only Amplify apps cannot deploy the SvelteKit SSR artifact correctly.
 2. Configure the app to use repository root as base and [`amplify.yml`](../amplify.yml).
-3. In GitHub repository secrets, add:
+3. Set the monorepo app root to `apps/misneach-web`. The deploy workflow also enforces `AMPLIFY_MONOREPO_APP_ROOT=apps/misneach-web` before starting a release.
+4. In GitHub repository secrets, add:
    - `AMPLIFY_WEB_APP_ID`
    - `AWS_REGION`
    - `AWS_ACCESS_KEY_ID`
    - `AWS_SECRET_ACCESS_KEY`
-4. In Amplify app environment variables, set any `PUBLIC_*` variables needed by `apps/misneach-web`.
-5. Set web runtime API variables in Amplify environment:
+5. Ensure the AWS deploy user can call these Amplify actions for the app:
+   - `amplify:GetApp`
+   - `amplify:UpdateApp`
+   - `amplify:StartJob`
+   - `amplify:GetJob`
+   - `amplify:GetBranch`
+6. In Amplify app environment variables, set any `PUBLIC_*` variables needed by `apps/misneach-web`.
+7. Set web runtime API variables in Amplify environment:
    - `PUBLIC_API_BASE_URL` = browser-facing API URL
+   - `PUBLIC_SURVEY_QR_BASE_URL` = public base URL for survey QR links
    - `PUBLIC_API_URL` = serverless public waitlist/survey API URL
    - `API_INTERNAL_URL` = primary server-side upstream
    - `API_INTERNAL_URLS` = optional comma-separated fallback upstreams
+   - `BUSINESS_INTERNAL_URL` = business/onboarding upstream
+   - `BUSINESS_INTERNAL_URLS` = optional comma-separated fallback upstreams
+   - `WAITLIST_API_URL` = optional waitlist upstream override
+   - `WAITLIST_API_URLS` = optional comma-separated waitlist fallback upstreams
+   - `SURVEYS_API_URL` = optional surveys upstream override
+   - `SURVEYS_API_URLS` = optional comma-separated surveys fallback upstreams
+   - `INTERNAL_AUTH_SECRET` = shared internal auth secret used by server-side API calls
    - `APP_BASE_URL` = public web URL (for example `https://misneach.ie`)
 
 ## Deploy Flows
 
-- Automatic: temporarily disabled while the Amplify app IAM role/build configuration is repaired.
+- Automatic: pushes to `main` that touch production application paths trigger [`full-app-deploy.yml`](../.github/workflows/full-app-deploy.yml), which deploys backend compose first and then calls [`web-amplify-deploy.yml`](../.github/workflows/web-amplify-deploy.yml).
 - Manual: run `Web Deploy (Amplify)` workflow and set branch input.
-- The deploy workflow starts a connected Amplify branch build with `amplify start-job --job-type RELEASE`; it does not upload a manual zip because Amplify manual deploys do not support SSR apps.
+- The deploy workflow applies [`amplify.yml`](../amplify.yml), verifies the Amplify app root is `apps/misneach-web`, then starts a connected Amplify branch build with `amplify start-job --job-type RELEASE`.
+- It does not upload a manual zip because Amplify manual deploys do not support SSR apps.
 - Deploy workflow smoke checks validate:
   - `GET /taster`
   - `GET /api/courses/taster`
@@ -38,3 +54,9 @@ This runbook deploys `apps/misneach-web` to AWS Amplify Hosting.
 
 - `apps/misneach-web` now uses `amplify-adapter` in `svelte.config.js`.
 - If build fails on missing runtime deps, verify `amplify.yml` includes the install step under `apps/misneach-web/build/compute/default`.
+
+Rollback:
+
+1. Open the Amplify app for `misneach-web`.
+2. Select branch `main`.
+3. Redeploy the last known-good successful job, or revert the bad commit and let `Full Application Deploy` run again from `main`.


### PR DESCRIPTION
## Summary

-

## Linked Issue

Closes #251

## Deployment Metadata

- Deploy impact label: `deploy:frontend` | `deploy:backend` | `deploy:both` | `deploy:none`
- Environment label: `env:staging` | `env:prod`

## Documentation Impact

- [ ] Updated deployment docs (`docs/deployment.md`) if deploy/config behavior changed
- [ ] Updated architecture docs (`docs/architecture.md` or `docs/adr/*`) if service interaction/topology changed
- [x] No architecture documentation impact
- [x] No documentation impact

## Validation

- [ ] Tests/build pass locally or in CI
- [ ] Rollout plan included (for risky changes)
- [ ] Rollback plan included (for risky changes)
