### PR TITLE
fix: include taster in misneach repo for public access

### DIFF
--- a/apps/misneach-web/src/lib/server/taster-content.ts
+++ b/apps/misneach-web/src/lib/server/taster-content.ts
@@ -1,0 +1,99 @@
+import {
+  buildLessonScreensFromPayload,
+  type CorePhrase,
+  type LessonPayload,
+  type LessonScreen,
+} from '@decyphr/misneach-ui';
+import tasterLesson from '../../../../../services/courses/src/content/lessons/cafe/cafe-first-encounters-lesson-1-1-conversation.json';
+import type { LessonContent } from '../../../../../services/courses/src/courses/courses.types';
+
+const bundledTasterLesson = tasterLesson as LessonContent;
+
+function buildCoreFlow(lesson: LessonContent): CorePhrase[] {
+  const coreFlow: CorePhrase[] = [];
+
+  for (const block of lesson.blocks) {
+    if (block.type !== 'dialogue') continue;
+
+    for (const [index, turn] of (block.turns || []).entries()) {
+      if (!turn.text) continue;
+
+      coreFlow.push({
+        phraseId: `${lesson.lessonSlug}:${block.id}:${index + 1}`,
+        blockId: block.id,
+        speaker: turn.speaker || 'Speaker',
+        text: turn.text,
+        pronunciation: turn.pronunciation,
+        translation: turn.translation,
+        retrievalPrompt: turn.translation
+          ? {
+              type: 'translate_to_irish',
+              prompt: `How do you say: "${turn.translation}"`,
+              expected: turn.text,
+            }
+          : undefined,
+      });
+    }
+  }
+
+  return coreFlow;
+}
+
+function buildTasterPayload(lesson: LessonContent): LessonPayload {
+  return {
+    lesson: {
+      courseSlug: lesson.courseSlug,
+      courseTitle: lesson.courseTitle,
+      lessonSlug: lesson.lessonSlug,
+      lessonTitle: lesson.lessonTitle,
+      estimatedMinutes: lesson.estimatedMinutes,
+      contentVersion: lesson.contentVersion,
+    },
+    progress: {
+      status: 'not_started',
+      progressPercent: 0,
+      lastBlockId: lesson.blocks[0]?.id ?? null,
+      contentVersion: lesson.contentVersion,
+    },
+    pedagogy: {
+      core_flow: buildCoreFlow(lesson),
+    },
+    blocks: lesson.blocks,
+  };
+}
+
+export function loadBundledTasterUnit(): {
+  courseTitle: string;
+  screens: LessonScreen[];
+} {
+  const lessonPayload = buildTasterPayload(bundledTasterLesson);
+
+  const intro: LessonScreen = {
+    kind: 'intro',
+    id: 'unit-screen-intro',
+    tag: 'Unit 1 · Coffee Shop Encounters',
+    title: 'An Caife.',
+    subtitle: 'A full real-world encounter — from hello to goodbye.',
+    chips: ['Greetings', 'Ordering', 'Payment', 'Add-ons', 'Milk swaps', 'Real world challenge'],
+  };
+
+  const lessonScreens = buildLessonScreensFromPayload(lessonPayload, {
+    idPrefix: 'unit1-1',
+    includeIntro: false,
+    includeRecap: false,
+    includeFinal: false,
+    includeFallbackNotes: false,
+  });
+
+  const final: LessonScreen = {
+    kind: 'final',
+    id: 'unit-screen-final',
+    headline: 'Aonad 1 criochnaithe.',
+    body: 'Unit 1 complete. You covered the full coffee shop encounter in Irish.',
+  };
+
+  return {
+    courseTitle: bundledTasterLesson.courseTitle,
+    screens: [intro, ...lessonScreens, final],
+  };
+}

--- a/apps/misneach-web/src/routes/taster/+page.server.ts
+++ b/apps/misneach-web/src/routes/taster/+page.server.ts
@@ -1,91 +1,15 @@
-import {
-  buildLessonScreensFromPayload,
-  type LessonPayload,
-  type LessonScreen,
-} from '@decyphr/misneach-ui';
-import { nestFetch } from '$lib/server/api';
+import { loadBundledTasterUnit } from '$lib/server/taster-content';
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async (event) => {
-  let courseTitle = 'Coffee Shop Encounters';
-  let screens: LessonScreen[] = [];
-
+export const load: PageServerLoad = async () => {
   try {
-    const response = await nestFetch(event, '/courses/taster', { method: 'GET' }, false);
-    if (!response.ok) {
-      throw new Error(`Failed to load taster content (${response.status})`);
-    }
-
-    const payload = (await response.json()) as {
-      lesson?: Record<string, unknown>;
-      progress?: LessonPayload['progress'];
-      pedagogy?: LessonPayload['pedagogy'];
-    };
-
-    const lesson = payload.lesson || {};
-    const blocks = Array.isArray(lesson['blocks']) ? (lesson['blocks'] as LessonPayload['blocks']) : [];
-
-    if (!blocks.length) {
-      throw new Error('Taster lesson returned no content blocks');
-    }
-
-    courseTitle = String(lesson.courseTitle || courseTitle);
-
-    const lessonPayloads: LessonPayload[] = [
-      {
-        lesson: {
-          courseSlug: String(lesson.courseSlug || 'cafe'),
-          courseTitle,
-          lessonSlug: String(lesson.lessonSlug || 'taster'),
-          lessonTitle: String(lesson.lessonTitle || 'Taster Lesson'),
-          estimatedMinutes: Number(lesson.estimatedMinutes || 4),
-          contentVersion: String(lesson.contentVersion || 'taster'),
-        },
-        progress: payload.progress || {
-          status: 'not_started',
-          progressPercent: 0,
-          lastBlockId: null,
-          contentVersion: String(lesson.contentVersion || 'taster'),
-        },
-        pedagogy: payload.pedagogy,
-        blocks,
-      },
-    ];
-
-    const intro: LessonScreen = {
-      kind: 'intro',
-      id: 'unit-screen-intro',
-      tag: 'Unit 1 · Coffee Shop Encounters',
-      title: 'An Caife.',
-      subtitle: 'A full real-world encounter — from hello to goodbye.',
-      chips: ['Greetings', 'Ordering', 'Payment', 'Add-ons', 'Milk swaps', 'Real world challenge'],
-    };
-
-    const allLessonScreens = lessonPayloads.flatMap((lessonPayload, idx) =>
-      buildLessonScreensFromPayload(lessonPayload, {
-        idPrefix: `unit1-${idx + 1}`,
-        includeIntro: false,
-        includeRecap: false,
-        includeFinal: false,
-        includeFallbackNotes: false,
-      }),
-    );
-
-    const final: LessonScreen = {
-      kind: 'final',
-      id: 'unit-screen-final',
-      headline: 'Aonad 1 criochnaithe.',
-      body: 'Unit 1 complete. You covered the full coffee shop encounter in Irish.',
-    };
-
-    screens = [intro, ...allLessonScreens, final];
+    return loadBundledTasterUnit();
   } catch (error) {
     console.error('Failed to load taster unit screens', error);
-    screens = [];
-  }
 
-  return {
-    courseTitle,
-    screens,
-  };
+    return {
+      courseTitle: 'Coffee Shop Encounters',
+      screens: [],
+    };
+  }
 };


### PR DESCRIPTION
## Summary

-

## Linked Issue

Closes #253 

## Deployment Metadata

- Deploy impact label: `deploy:frontend` | `deploy:backend` | `deploy:both` | `deploy:none`
- Environment label: `env:staging` | `env:prod`

## Documentation Impact

- [ ] Updated deployment docs (`docs/deployment.md`) if deploy/config behavior changed
- [ ] Updated architecture docs (`docs/architecture.md` or `docs/adr/*`) if service interaction/topology changed
- [x] No architecture documentation impact
- [x] No documentation impact

## Validation

- [ ] Tests/build pass locally or in CI
- [ ] Rollout plan included (for risky changes)
- [ ] Rollback plan included (for risky changes)
